### PR TITLE
enable certus quartz tools

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -134,7 +134,7 @@ features {
     }
 
     toolsclassifications {
-        B:CertusQuartzTools=false
+        B:CertusQuartzTools=true
         B:NetherQuartzTools=false
         B:PoweredTools=true
     }


### PR DESCRIPTION
enable certus quartz tools so we have the ability to rename AE parts