### PR TITLE
feature/FTB-Utils-Config

### DIFF
--- a/local/ftblib.json
+++ b/local/ftblib.json
@@ -1,0 +1,17 @@
+{
+  "compat": {
+    "compat_statusEffectHUD": false
+  },
+  "commands": {
+    "override_list": true,
+    "override_help": true,
+    "set_item_name": "op",
+    "trash_can": "all"
+  },
+  "command_names": {
+    "reload": "reload",
+    "edit_config": "edit_config",
+    "set_item_name": "set_item_name",
+    "trash_can": "trash_can"
+  }
+}

--- a/local/ftbu/config.json
+++ b/local/ftbu/config.json
@@ -1,0 +1,84 @@
+{
+  "backups": {
+    "enabled": true,
+    "backups_to_keep": 12,
+    "backup_timer": 2.0,
+    "compression_level": 1,
+    "folder": "./backups/",
+    "display_file_size": true,
+    "use_separate_thread": true,
+    "need_online_players": true
+  },
+  "commands": {
+    "name_admin": "admin",
+    "back": true,
+    "home": true,
+    "spawn": true,
+    "tplast": true,
+    "warp": true
+  },
+  "general": {
+    "restart_timer": 0.0,
+    "safe_spawn": false,
+    "spawn_pvp": true,
+    "blocked_entities": [],
+    "spawn_area_in_sp": false,
+    "server_info_difficulty": true,
+    "server_info_mode": true
+  },
+  "login": {
+    "motd": [
+      "Welcome to the server!"
+    ],
+    "starting_items": [
+      "minecraft:apple 16 0"
+    ]
+  },
+  "tops": {
+    "first_joined": true,
+    "last_seen": true,
+    "time_played": true,
+    "deaths": true,
+    "deaths_ph": true
+  },
+  "chunkloading": {
+    "enabled": true,
+    "max_player_offline_hours": -1.0
+  },
+  "permissions_admin": {
+    "custom_config": {},
+    "max_claims": 1000,
+    "max_homes": 100,
+    "cross_dim_homes": true,
+    "cross_dim_warp": true,
+    "forced_explosions": "-",
+    "forced_chunk_security": "-",
+    "break_whitelist": [
+      "OpenBlocks:grave"
+    ],
+    "dimension_blacklist": [],
+    "allow_creative_interact_secure": true,
+    "max_loaded_chunks": 50,
+    "show_rank": true,
+    "badge": ""
+  },
+  "permissions_player": {
+    "custom_config": {},
+    "max_claims": 100,
+    "max_homes": 1,
+    "cross_dim_homes": true,
+    "cross_dim_warp": true,
+    "forced_explosions": "-",
+    "forced_chunk_security": "-",
+    "break_whitelist": [
+      "OpenBlocks:grave"
+    ],
+    "dimension_blacklist": [
+      1
+    ],
+    "allow_creative_interact_secure": false,
+    "max_loaded_chunks": 50,
+    "show_rank": true,
+    "badge": ""
+  }
+}

--- a/local/ftbu/config.json
+++ b/local/ftbu/config.json
@@ -1,6 +1,6 @@
 {
   "backups": {
-    "enabled": true,
+    "enabled": false,
     "backups_to_keep": 12,
     "backup_timer": 2.0,
     "compression_level": 1,
@@ -20,7 +20,7 @@
   "general": {
     "restart_timer": 0.0,
     "safe_spawn": false,
-    "spawn_pvp": true,
+    "spawn_pvp": false,
     "blocked_entities": [],
     "spawn_area_in_sp": false,
     "server_info_difficulty": true,
@@ -31,7 +31,6 @@
       "Welcome to the server!"
     ],
     "starting_items": [
-      "minecraft:apple 16 0"
     ]
   },
   "tops": {


### PR DESCRIPTION
Initial configuration changes for ftb utils. Right now all this does is disable backups and remove the starting apples. I'm not sure what other config changes if any we want to make. I'd like to keep this set as a draft tell next sunday for the RC3 release.